### PR TITLE
Fix the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist
 /node_modules
+/rollup-plugin-root-import.sublime-workspace

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,19 @@
+{
+  // If you are using SublimeLinter, after modifying this config file, be sure to close and reopen
+  // the file(s) you were editing to see the changes take effect.
+
+  // Prohibit the use of undeclared variables.
+  "undef": true,
+
+  // Suppress warnings about using [] notation when it can be expressed in dot notation,
+  // so that we can use [] notation to highlight when objects are used as maps.
+  "sub": true,
+
+  // Warn for unused variables and function parameters.
+  "unused": true,
+
+  // Make JSHint aware of Node globals.
+  "node": true,
+
+  "esnext": true
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "homepage": "https://github.com/mixmaxhq/rollup-plugin-root-import#readme",
   "devDependencies": {
-    "babel-preset-es2015-rollup": "^1.1.1",
+    "babel-plugin-external-helpers": "^6.18.0",
+    "babel-preset-es2015": "^6.18.0",
     "chai": "^3.5.0",
     "mocha": "^2.5.3",
     "rewire": "^2.5.2",

--- a/rollup-plugin-root-import.sublime-project
+++ b/rollup-plugin-root-import.sublime-project
@@ -1,0 +1,17 @@
+{
+  "folders": [{
+    "path": ".",
+    "folder_exclude_patterns": [
+      "node_modules",
+      "dist"
+    ]
+  }],
+  "settings": {
+    "tab_size": 2,
+    "ensure_newline_at_eof_on_save": true,
+    "translate_tabs_to_spaces": true,
+    "trim_trailing_white_space_on_save": true,
+    "detect_indentation": false,
+    "rulers": [100]
+  }
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,17 @@ export default {
   entry: 'lib/index.js',
   plugins: [
     babel({
-      presets: ['es2015-rollup']
+      presets: [
+        [
+          'es2015',
+          {
+            modules: false
+          }
+        ]
+      ],
+      plugins: [
+        'external-helpers'
+      ]
     })
   ],
   targets: [


### PR DESCRIPTION
One of the dependencies of `babel-preset-es2015-rollup` has broken,
causing this error when building:

> “Error transforming /Users/jeffreywear/Documents/Source/Mixmax/rollup-plugin-root-import/lib/index.js with 'babel' plugin: Cannot find module 'es2015' (While processing preset: "/Users/jeffreywear/Documents/Source/Mixmax/rollup-plugin-root-import/node_modules/babel-preset-es2015-rollup/index.js")

But, `rollup-plugin-babel` no longer requires `babel-preset-es2015-rollup`,
they now recommend using `babel-preset-2015` and `babel-plugin-external-helpers`:
https://github.com/rollup/rollup-plugin-babel#modules So, we just switch to
that.