### PR TITLE
Resolve `${importee}/index${extension}` as well

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,6 +95,7 @@ export default function rootImport(options) {
   if (!roots && options && typeof options === 'object') {
     roots = strArray(options.root);
     extensions = strArray(options.extensions);
+    extensions = extensions ? extensions.concat(extensions.map(ext => `/index${ext}`)) : extensions;
 
     if (~['prepend', 'append'].indexOf(options.useEntry)) {
       useEntry = options.useEntry;


### PR DESCRIPTION
Some module is in a sub directory, and use index.(js,ts...) as entry point.
This PR adds the ability to always lookup this kind of module.

Use a simple and quick fix by adding more extensions after receive it.